### PR TITLE
include .gitattributes and declare .st files as Smalltalk files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# inform linguist that files with these extensions are indeed smalltalk files
+*.st linguist-language=Smalltalk


### PR DESCRIPTION
Turn that 97.7% smalltalk:
![image](https://user-images.githubusercontent.com/623951/66337490-17c59600-e8f4-11e9-80fa-cf1692d484d8.png)
into 100% smalltalk files:
![image](https://user-images.githubusercontent.com/623951/66337421-f2d12300-e8f3-11e9-81e3-ea835ef58032.png)

By default Github thinks that .st files are html files, this is a somewhat recent change (last couple of years), and with the .gitattributes file, you can declare the extension to language mapping.

Should include a .gitattributes file in your new tonel-based projects ....
